### PR TITLE
cmake: build the required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(hidviz VERSION 0.2 LANGUAGES C CXX)
 


### PR DESCRIPTION
Versions older than 3.10 are deprecated, so let's bump it to 3.10. See https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required