### PR TITLE
cmake: bump required version to 3.10 everywhere

### DIFF
--- a/hidviz/CMakeLists.txt
+++ b/hidviz/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 
 # Cmake 3.17 changed automoc behaviour for header files with .hh extension.
 # Now these files are passed to automoc. When policy is set to <3.17, these

--- a/libhidx/CMakeLists.txt
+++ b/libhidx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 find_package(asio REQUIRED)

--- a/libhidx/libhidx/CMakeLists.txt
+++ b/libhidx/libhidx/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(libhidx VERSION 0.0.1 LANGUAGES C CXX)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/libhidx/libhidx_server/CMakeLists.txt
+++ b/libhidx/libhidx_server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(libhidx_server VERSION 0.0.1 LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")

--- a/libhidx/libhidx_server_daemon/CMakeLists.txt
+++ b/libhidx/libhidx_server_daemon/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 project(libhidx_server VERSION 0.0.1 LANGUAGES C CXX)
 
 add_executable(libhidx_server_daemon


### PR DESCRIPTION
#43 missed these files, and CMake 4 complains about them.